### PR TITLE
重さのスイッチ修正

### DIFF
--- a/trickleLibrary/OG2D/src/Gimmick/NO_MOVE/WeightSwitch.cpp
+++ b/trickleLibrary/OG2D/src/Gimmick/NO_MOVE/WeightSwitch.cpp
@@ -88,7 +88,7 @@ void WeightSwitch::UpDate()
 		this->state = Nomal;
 	}
 
-	if (this->isPushed) {
+	if (this->nowActive) {
 		ToOpen();
 	}
 	else {

--- a/trickleLibrary/OG2D/src/Gimmick/NO_MOVE/WeightSwitch.h
+++ b/trickleLibrary/OG2D/src/Gimmick/NO_MOVE/WeightSwitch.h
@@ -12,7 +12,7 @@ class WeightSwitch :public GameObject, public TaskObject
 	std::string taskName;
 	Box2D draw;
 	Box2D src;
-	bool nowActive;          //今扉を開けるかどうか
+	bool nowActive;             //今扉を開けるかどうか
 	bool canPlhitCheck;         //プレイヤと当たり判定をして良いか
 	bool canIcehitCheck;        //氷と当たり判定をしてよいか
 	bool canBlockhitCheck;      //ブロックと当たり判定をしてよいか
@@ -46,7 +46,7 @@ public:
 	bool SetnowState();             //今のスイッチの状態を返す
 	void SetTexture(Texture*);      //画像のセット
 	float SetSwitchUpPos();         //スイッチが元の大きさに戻った時にめり込まないようにする処理
-	bool isPushed;
+	bool isPushed;                  //一度扉が開いたかどうか
 	static SP Create(const Vec2& pos, const Vec2& size, const float mass, std::vector<std::shared_ptr<GameObject>> targets_);
 };
 


### PR DESCRIPTION
スイッチが開きっぱなしになる現象の修正終了しました。
原因は、追加してあった処理で、扉を開け閉めするためにif文で使用していたbool型変数が一度開いていたらオンにするものだったためでした。(isPushed)
nowActiveを使用すれば正常に動きます、変数名の使い方がわかりづらくてすみません。